### PR TITLE
修正　回転と移動の制御

### DIFF
--- a/Shooting/Shooting/BoundingBox.cpp
+++ b/Shooting/Shooting/BoundingBox.cpp
@@ -8,6 +8,7 @@
 //R right   <--->L left
 //U up      <--->D down
 
+
 #define VERTEX_FRU 0
 #define VERTEX_FLU 1
 #define VERTEX_BRU 2

--- a/Shooting/Shooting/DirectX_note.props
+++ b/Shooting/Shooting/DirectX_note.props
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>C:\Program Files %28x86%29\Microsoft DirectX SDK %28June 2010%29\Lib\x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/Shooting/Shooting/Game/Player.h
+++ b/Shooting/Shooting/Game/Player.h
@@ -41,8 +41,11 @@ private:
 	//プレイヤーの位置
 	D3DXVECTOR3 PlayerPos;
 	//プレイヤーの向き
-	D3DXVECTOR3 PlayerAngle;
+	//D3DXVECTOR3 PlayerAngle;
+	D3DXVECTOR3 Direction;
 
+	float PlayerYaw;
+	float PlayerPitch;
 
 
 	//各方向のベクトル

--- a/Shooting/Shooting/Shooting.vcxproj
+++ b/Shooting/Shooting/Shooting.vcxproj
@@ -58,12 +58,14 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="DirectX_note.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="DirectX_note.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />


### PR DESCRIPTION
branch :Fix_KousukeFujii

回転と移動の制御とカメラの追従がYawとPitchのみで行われるように修正
弾の出現位置や飛ぶ方向については前のままです

ご参考に